### PR TITLE
Lime Go requires that a coworker have an email

### DIFF
--- a/lib/move-to-go/model/coworker.rb
+++ b/lib/move-to-go/model/coworker.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module MoveToGo
     class Coworker < CanBecomeImmutable
         include SerializeHelper
@@ -76,6 +75,21 @@ module MoveToGo
             firstname = to_email_chars @first_name.downcase
             lastname = to_email_chars @last_name.downcase
             return "#{firstname}.#{lastname}@#{domain}"
+        end
+
+        def validate
+            error = String.new
+
+            if (@first_name.nil? || @first_name.empty?) &&
+               (@last_name.nil? || @last_name.empty?)
+                error = "A firstname or lastname is required for coworker.\n#{serialize()}"
+            end
+
+            if @email.nil? || @email.empty?
+                error = "#{error}\nAn email is required for coworker.\n"
+            end
+            
+            return error
         end
 
     end

--- a/lib/move-to-go/model/rootmodel.rb
+++ b/lib/move-to-go/model/rootmodel.rb
@@ -5,7 +5,7 @@ require 'securerandom'
 require "progress"
 
 module MoveToGo
-    # The root model for Go import. This class is the container for everything else.
+    # The root model for Move To Go. This class is the container for everything else.
     class RootModel
         # the migrator_coworker is a special coworker that is set as
         # responsible for objects that requires a coworker, eg a history.
@@ -48,6 +48,7 @@ module MoveToGo
             @migrator_coworker = Coworker.new
             @migrator_coworker.integration_id = "migrator"
             @migrator_coworker.first_name = "Migrator"
+            @migrator_coworker.email = "noreply-migrator@lime-go.com"
             @coworkers[@migrator_coworker.integration_id] = @migrator_coworker
             @deals = {}
             @histories = {}
@@ -474,6 +475,14 @@ module MoveToGo
             errors = String.new
             warnings = String.new
 
+            @coworkers.each do |key, coworker|
+                validation_mesage = coworker.validate
+
+                if !validation_mesage.empty?
+                    errors = "#{errors}\n#{validation_mesage}"
+                end
+            end
+            
             @organizations.each do |k, o|
                 validation_message = o.validate()
 
@@ -481,7 +490,7 @@ module MoveToGo
                     errors = "#{errors}\n#{validation_message}"
                 end
             end
-
+            
             converter_deal_statuses = @settings.deal.statuses.map {|status| status.label} if @settings.deal != nil
             @deals.each do |key, deal|
                 error, warning = deal.validate converter_deal_statuses

--- a/spec/coworker_spec.rb
+++ b/spec/coworker_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "spec_helper"
 require 'move-to-go'
 
@@ -7,6 +6,42 @@ describe "Coworker" do
         MoveToGo::Coworker.new
     }
 
+    describe "coworker" do
+        it "must have a first name and email" do
+            # given
+            coworker.first_name = "billy"
+            coworker.email = "billy@movetogo.com"
+
+            # when, then
+            coworker.validate.should eq ""
+        end
+
+        it "must have a last name and email" do
+            # given
+            coworker.first_name = "bob"
+            coworker.email = "billy@movetogo.com"
+
+            # when, then
+            coworker.validate.should eq ""
+        end
+        
+        it "must have either first or last name and email" do
+            # given
+            coworker.email = "billy@movetogo.com"
+
+            # when, then
+            coworker.validate.length.should > 1 
+        end      
+
+          it "must have email" do
+            # given
+            coworker.first_name = "billy"
+            
+            # when, then
+            coworker.validate.length.should > 1 
+        end         
+    end
+    
     describe "parse_name_to_firstname_lastname_se" do
         it "can parse 'Kalle Nilsson' into firstname 'Kalle' and lastname 'Nilsson'" do
             coworker.parse_name_to_firstname_lastname_se 'Kalle Nilsson'

--- a/spec/rootmodel_spec.rb
+++ b/spec/rootmodel_spec.rb
@@ -11,6 +11,10 @@ describe "RootModel" do
         rootmodel.coworkers.length.should eq 1
     end
 
+    it "will contain a migration coworker with email" do
+        rootmodel.find_coworker_by_integration_id("migrator").email.length.should > 1 
+    end
+
     it "can add a coworker from a new coworker" do
         # given
         coworker = MoveToGo::Coworker.new


### PR DESCRIPTION
Lime Go now requires that a coworker have an email address. 

We dont want move-to-go to create invalid files.