### PR TITLE
Prevent the use of old move-to-go versions.

### DIFF
--- a/bin/move-to-go
+++ b/bin/move-to-go
@@ -14,7 +14,7 @@ class MoveToGoCommandLine < Thor
     desc "about", "About move-to-go"
     def about()
         display_current_version()
-        puts "move-to-go is an migration tool for LIME Go. It can take virtually any input source and create import data files that LIME Go likes." 
+        puts "move-to-go is an migration tool for Lime Go. It can take virtually any input source and create import data files that Lime Go likes." 
         puts "move-to-go has some predefined sources that will make it easy for you to migrate your data."
         puts ""
     end
@@ -46,7 +46,7 @@ class MoveToGoCommandLine < Thor
 
     desc "new <PROJECT> <SOURCE>", "Creates a new migration project with a specifed name and source"
     option(:force_current_version,
-           :desc => "Set this if you have an outdated version of move-to-go and still want to create a new migration. Old versions of move-to-go will not work with the current version of LIME Go.",
+           :desc => "Set this if you have an outdated version of move-to-go and still want to create a new migration. Old versions of move-to-go will not work with the current version of Lime Go.",
            :type => :boolean,
            :required => false)
     def new(project, source)
@@ -61,13 +61,13 @@ class MoveToGoCommandLine < Thor
         if sources.create_project_from_source(project, source)
             puts "\nProject '#{project}' created from source '#{source}'."
             puts "Modify the #{project}/converter.rb script to suit your source."
-            puts "Use 'move-to-go run' from the project directory to create the zip file for LIME Go."
+            puts "Use 'move-to-go run' from the project directory to create the zip file for Lime Go."
         end
     end
 
     desc "run", "Executes the current project and create a go.zip file with data and files. Existing go.zip will be overwritten, use --output to specify a different filename."
     option(:output,
-           :desc => "Name of the file where the converted source will be saved. This file should be sent to LIME Go. If the file already exist it will be replaced.",
+           :desc => "Name of the file where the converted source will be saved. This file should be sent to Lime Go. If the file already exist it will be replaced.",
            :type => :string,
            :required => false)
     option(:ignore_invalid_files,
@@ -91,7 +91,7 @@ class MoveToGoCommandLine < Thor
            :type => :numeric,
            :required => false)
     option(:force_current_version,
-           :desc => "Set this if you have an outdated version of move-to-go and still want to run the migration. Old versions of move-to-go will not work with the current version of LIME Go.",
+           :desc => "Set this if you have an outdated version of move-to-go and still want to run the migration. Old versions of move-to-go will not work with the current version of Lime Go.",
            :type => :boolean,
            :required => false)
     def run_import()

--- a/bin/move-to-go
+++ b/bin/move-to-go
@@ -3,6 +3,8 @@
 require "thor"
 require_relative '../lib/move-to-go'
 require 'progress'
+require 'net/http'
+require 'json'
 
 
 RUNNER_DIR = ".move-to-go"
@@ -32,14 +34,21 @@ class MoveToGoCommandLine < Thor
 
     desc "about <SOURCE>", "Prints information about the specifed source"
     def about(source)
-
         sources = MoveToGo::Sources.new(source_path)
 
         sources.about_source(source)
     end
 
     desc "new <PROJECT> <SOURCE>", "Creates a new migration project with a specifed name and source"
+    option(:ignore_version,
+           :desc => "Ignore version check",
+           :type => :boolean,
+           :required => false)
     def new(project, source)
+        if options.ignore_version.nil?
+            verify_version()
+        end
+
         sources = MoveToGo::Sources.new(source_path)
 
         if sources.create_project_from_source(project, source)
@@ -74,7 +83,15 @@ class MoveToGoCommandLine < Thor
            :desc => "Large imports are sharded into several zip-files. This property sets how many objects each zip-file should contain. Default is 25 000",
            :type => :numeric,
            :required => false)
+    option(:ignore_version,
+           :desc => "Ignore version check",
+           :type => :boolean,
+           :required => false)
     def run_import()
+        if options.ignore_version.nil?
+            verify_version()
+        end
+
         if !options.log_to_file.nil?
             $stdout = File.new(options.log_to_file == "log_to_file" ? "move-to-go.log" : options.log_to_file, 'w')
             $stdout.sync = true
@@ -210,7 +227,28 @@ class MoveToGoCommandLine < Thor
     def source_path()
         File.expand_path("../sources", File.dirname(__FILE__))
     end
+
+    private
+    def verify_version()
+        uri = URI('https://rubygems.org/api/v1/versions/move-to-go/latest.json')
+
+        Net::HTTP.start(uri.host, uri.port,
+        :verify_mode => OpenSSL::SSL::VERIFY_NONE,
+        :use_ssl => true) do |http|
+
+            request = Net::HTTP::Get.new uri
+            response = http.request request
+
+            latest_version = Gem::Version.new(JSON.parse(response.body)['version'])
+            current_version = Gem.loaded_specs["move-to-go"].version
+            outdated = latest_version > current_version
+
+            if outdated
+                puts "You are running an old version of move-to-go (#{current_version})\r\nPlease upgrade by running 'gem install move-to-go'"
+                exit
+            end
+        end
+    end
 end
 
-puts "Version: #{Gem.loaded_specs["move-to-go"].version}"
 MoveToGoCommandLine.start(ARGV)

--- a/bin/move-to-go
+++ b/bin/move-to-go
@@ -13,6 +13,7 @@ class MoveToGoCommandLine < Thor
 
     desc "about", "About move-to-go"
     def about()
+        display_current_version()
         puts "move-to-go is an migration tool for LIME Go. It can take virtually any input source and create import data files that LIME Go likes." 
         puts "move-to-go has some predefined sources that will make it easy for you to migrate your data."
         puts ""
@@ -20,6 +21,8 @@ class MoveToGoCommandLine < Thor
 
     desc "list-sources", "Lists the available sources"
     def list_sources()
+        display_current_version()
+
         puts "The following sources are available:"
         puts
 
@@ -34,20 +37,24 @@ class MoveToGoCommandLine < Thor
 
     desc "about <SOURCE>", "Prints information about the specifed source"
     def about(source)
+        display_current_version()
+
         sources = MoveToGo::Sources.new(source_path)
 
         sources.about_source(source)
     end
 
     desc "new <PROJECT> <SOURCE>", "Creates a new migration project with a specifed name and source"
-    option(:ignore_version,
-           :desc => "Ignore version check",
+    option(:force_current_version,
+           :desc => "Set this if you have an outdated version of move-to-go and still want to create a new migration. Old versions of move-to-go will not work with the current version of LIME Go.",
            :type => :boolean,
            :required => false)
     def new(project, source)
-        if options.ignore_version.nil?
-            verify_version()
+        if options.force_current_version.nil?
+            check_current_version()
         end
+
+        display_current_version()
 
         sources = MoveToGo::Sources.new(source_path)
 
@@ -83,14 +90,16 @@ class MoveToGoCommandLine < Thor
            :desc => "Large imports are sharded into several zip-files. This property sets how many objects each zip-file should contain. Default is 25 000",
            :type => :numeric,
            :required => false)
-    option(:ignore_version,
-           :desc => "Ignore version check",
+    option(:force_current_version,
+           :desc => "Set this if you have an outdated version of move-to-go and still want to run the migration. Old versions of move-to-go will not work with the current version of LIME Go.",
            :type => :boolean,
            :required => false)
     def run_import()
-        if options.ignore_version.nil?
-            verify_version()
+        if options.force_current_version.nil?
+            check_current_version()
         end
+
+        display_current_version()
 
         if !options.log_to_file.nil?
             $stdout = File.new(options.log_to_file == "log_to_file" ? "move-to-go.log" : options.log_to_file, 'w')
@@ -229,7 +238,7 @@ class MoveToGoCommandLine < Thor
     end
 
     private
-    def verify_version()
+    def check_current_version()
         uri = URI('https://rubygems.org/api/v1/versions/move-to-go/latest.json')
 
         Net::HTTP.start(uri.host, uri.port,
@@ -242,12 +251,19 @@ class MoveToGoCommandLine < Thor
             latest_version = Gem::Version.new(JSON.parse(response.body)['version'])
             current_version = Gem.loaded_specs["move-to-go"].version
             outdated = latest_version > current_version
-
+            
             if outdated
-                puts "You are running an old version of move-to-go (#{current_version})\r\nPlease upgrade by running 'gem install move-to-go'"
+                puts "You are running an old version of move-to-go (#{current_version})"
+                puts "Please upgrade by running 'gem install move-to-go'"
                 exit
             end
         end
+    end
+
+    private
+    def display_current_version()
+        puts "Version: #{Gem.loaded_specs["move-to-go"].version}"
+        puts 
     end
 end
 

--- a/bin/move-to-go
+++ b/bin/move-to-go
@@ -16,7 +16,7 @@ class MoveToGoCommandLine < Thor
         display_current_version()
         puts "move-to-go is an migration tool for Lime Go. It can take virtually any input source and create import data files that Lime Go likes." 
         puts "move-to-go has some predefined sources that will make it easy for you to migrate your data."
-        puts ""
+        puts
     end
 
     desc "list-sources", "Lists the available sources"
@@ -31,7 +31,8 @@ class MoveToGoCommandLine < Thor
             puts "\t#{s}"
         end
 
-        puts "\nCreate a new project with 'move-to-go new <PROJECT> <SOURCE>' with one of these sources."
+        puts
+        puts "Create a new project with 'move-to-go new <PROJECT> <SOURCE>' with one of these sources."
         puts "Use 'move-to-go about <SOURCE>' for more information about a specific source."
     end
 
@@ -59,7 +60,8 @@ class MoveToGoCommandLine < Thor
         sources = MoveToGo::Sources.new(source_path)
 
         if sources.create_project_from_source(project, source)
-            puts "\nProject '#{project}' created from source '#{source}'."
+            puts
+            puts "Project '#{project}' created from source '#{source}'."
             puts "Modify the #{project}/converter.rb script to suit your source."
             puts "Use 'move-to-go run' from the project directory to create the zip file for Lime Go."
         end

--- a/bin/move-to-go
+++ b/bin/move-to-go
@@ -32,6 +32,7 @@ class MoveToGoCommandLine < Thor
 
     desc "about <SOURCE>", "Prints information about the specifed source"
     def about(source)
+
         sources = MoveToGo::Sources.new(source_path)
 
         sources.about_source(source)
@@ -211,4 +212,5 @@ class MoveToGoCommandLine < Thor
     end
 end
 
+puts "Version: #{Gem.loaded_specs["move-to-go"].version}"
 MoveToGoCommandLine.start(ARGV)

--- a/move-to-go.gemspec
+++ b/move-to-go.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
     s.name        = 'move-to-go'
-    s.version     = '5.0.7'
+    s.version     = '5.0.8'
     s.platform    = Gem::Platform::RUBY
     s.authors     = ['Petter Sandholdt', 'Oskar Gewalli', 'Peter Wilhelmsson', 'Anders Pålsson', 'Ahmad Game', 'Rickard Helldin']
     s.email       = 'support@lundalogik.se'

--- a/sources/VISMA/converter.rb
+++ b/sources/VISMA/converter.rb
@@ -41,7 +41,7 @@ class Converter
 
         #Creates a custom field to add invoicing data
         rootmodel.settings.with_organization do |org|
-            org.set_custom_field( { :integrationid => 'ackoms', :title => 'Fakturerat', :type => :String } )
+            org.set_custom_field( { :integration_id => 'ackoms', :title => 'Fakturerat', :type => :String } )
         end
     end
 

--- a/sources/csv/converter.rb
+++ b/sources/csv/converter.rb
@@ -46,7 +46,7 @@ class Converter
         # :String and :Link. If no type is specified :String is used
         # as default.
         rootmodel.settings.with_organization do |organization|
-            organization.set_custom_field( { :integrationid => 'external_url', :title => 'Link to external system', :type => :Link } )
+            organization.set_custom_field( { :integration_id => 'external_url', :title => 'Link to external system', :type => :Link } )
         end
 
         rootmodel.settings.with_deal do |deal|

--- a/sources/salesforce/converter.rb
+++ b/sources/salesforce/converter.rb
@@ -47,7 +47,7 @@ class Converter
 
         
 #        rootmodel.settings.with_organization do |organization|
-#            organization.set_custom_field( { :integrationid => 'external_url', :title => 'Link to external system', :type => :Link } )
+#            organization.set_custom_field( { :integration_id => 'external_url', :title => 'Link to external system', :type => :Link } )
 #        end
     end
 


### PR DESCRIPTION
Fixed typos in configure functions, integrationid -> integration_id.