### PR TITLE
Added, A simple validation for source id.

### DIFF
--- a/bin/move-to-go
+++ b/bin/move-to-go
@@ -136,9 +136,12 @@ class MoveToGoCommandLine < Thor
             model.report_rootmodel_status()
 
             puts "Checking for duplicate organizations..."
-            possible_duplicates = model.organizations.find_duplicates_by(:name, :organization_number)
+            possible_duplicates = model.organizations.find_duplicates_by(:name, :organization_number, :source)
             puts "Found #{possible_duplicates.length} organization duplicate sets in rootmodel, based on name and organization number"
-                
+
+            possible_duplicates = model.organizations.find_duplicates_by("source.id")
+            puts "Found #{possible_duplicates.length} organization duplicate sets in rootmodel, based on source id"
+
             puts "Starting sharding of model..."
             sharder = MoveToGo::ShardHelper.new(options.shard_size)
             models_to_serialize = sharder.shard_model(model)

--- a/bin/move-to-go
+++ b/bin/move-to-go
@@ -136,11 +136,8 @@ class MoveToGoCommandLine < Thor
             model.report_rootmodel_status()
 
             puts "Checking for duplicate organizations..."
-            possible_duplicates = model.organizations.find_duplicates_by(:name, :organization_number, :source)
+            possible_duplicates = model.organizations.find_duplicates_by(:name, :organization_number)
             puts "Found #{possible_duplicates.length} organization duplicate sets in rootmodel, based on name and organization number"
-
-            possible_duplicates = model.organizations.find_duplicates_by("source.id")
-            puts "Found #{possible_duplicates.length} organization duplicate sets in rootmodel, based on source id"
 
             puts "Starting sharding of model..."
             sharder = MoveToGo::ShardHelper.new(options.shard_size)

--- a/lib/move-to-go/model/organization.rb
+++ b/lib/move-to-go/model/organization.rb
@@ -69,6 +69,9 @@ module MoveToGo
         # :attr_accessor: central_phone_number
         immutable_accessor :central_phone_number
         ##
+        # :attr_accessor: source
+        immutable_accessor :source
+        ##
         # :attr_accessor: source_data
         immutable_accessor :source_data
         attr_accessor :rootmodel

--- a/lib/move-to-go/model/organization.rb
+++ b/lib/move-to-go/model/organization.rb
@@ -269,6 +269,8 @@ module MoveToGo
             if !@source.nil?
                 if @source.id.nil? || @source.id == ""
                     error = "#{error}\nReference to source must have an id"
+                elsif @source.id !~ /^\d{1}\d*:{1}\d{1}\d*$/
+                    error = "#{error}\nInvalid source id '%{id}, must have one ':' and only digits allowed, example '1:200010'" % { :id => @source.id }
                 end
             end
 

--- a/lib/move-to-go/model/organization.rb
+++ b/lib/move-to-go/model/organization.rb
@@ -270,7 +270,7 @@ module MoveToGo
                 if @source.id.nil? || @source.id == ""
                     error = "#{error}\nReference to source must have an id"
                 elsif @source.id !~ /^\d{1}\d*:{1}\d{1}\d*$/
-                    error = "#{error}\nInvalid source id '%{id}, must have one ':' and only digits allowed, example '1:200010'" % { :id => @source.id }
+                    error = "#{error}\nInvalid source id '#{@source.id}', must have one ':' and only digits allowed, example '1:200010'"
                 end
             end
 

--- a/lib/move-to-go/model/organizations.rb
+++ b/lib/move-to-go/model/organizations.rb
@@ -59,7 +59,7 @@ module MoveToGo
                     when Symbol then val = org.instance_variable_get(field)
                     when Array then val = org.instance_variable_get(field[0]).instance_variable_get(field[1])
                 end
-                val != nil ? val.downcase.strip : val = ''
+                val != nil ? val.to_s.downcase.strip : val = ''
                 }
             }
             .select { |k, v| v.size > 1 }

--- a/lib/move-to-go/model/rootmodel.rb
+++ b/lib/move-to-go/model/rootmodel.rb
@@ -117,6 +117,12 @@ module MoveToGo
                 raise AlreadyAddedError, "Already added an organization with integration_id #{organization.integration_id}"
             end
 
+            if !organization.source.nil?
+                if !@organizations.find{|key,value| value.source.id == organization.source.id if !value.source.nil?}.nil?
+                    raise AlreadyAddedError, "Source id already exists, sourceId: #{organization.source.id}"
+                end
+            end
+
             @organizations[organization.integration_id] = organization
             organization.rootmodel = self
             organization.set_is_immutable

--- a/move-to-go.gemspec
+++ b/move-to-go.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
     s.name        = 'move-to-go'
-    s.version     = '5.0.8'
+    s.version     = '5.0.9'
     s.platform    = Gem::Platform::RUBY
     s.authors     = ['Petter Sandholdt', 'Oskar Gewalli', 'Peter Wilhelmsson', 'Anders Pålsson', 'Ahmad Game', 'Rickard Helldin']
     s.email       = 'support@lundalogik.se'

--- a/spec/organization_spec.rb
+++ b/spec/organization_spec.rb
@@ -56,7 +56,7 @@ describe "Organization" do
         organization.validate.should eq ""
     end
 
-    it "will fail on validateion if it has a source with no sourceid" do
+    it "will fail on validation if it has a source with no sourceid" do
         # given
         organization.name =  "Lundalogik"
 
@@ -67,6 +67,72 @@ describe "Organization" do
 
         # then
         organization.validate.length.should be > 0
+    end
+
+    it "will fail on source validation, only numbers" do
+        # given
+        organization.name =  "Lundalogik"
+
+        # when
+        organization.with_source do |source|
+            source.par_se('11234')
+        end
+
+        # then
+        organization.validate.length.should be > 0
+    end
+
+
+    it "will fail on source validation, begins with :" do
+        # given
+        organization.name =  "Lundalogik"
+
+        # when
+        organization.with_source do |source|
+            source.par_se(':11234')
+        end
+
+        # then
+        organization.validate.length.should be > 0
+    end
+
+    it "will fail on source validation, ends with :" do
+        # given
+        organization.name =  "Lundalogik"
+
+        # when
+        organization.with_source do |source|
+            source.par_se('11234:')
+        end
+
+        # then
+        organization.validate.length.should be > 0
+    end
+
+    it "will not fail on source validation, pattern 1" do
+        # given
+        organization.name =  "Lundalogik"
+
+        # when
+        organization.with_source do |source|
+            source.par_se('1:1234')
+        end
+
+        # then
+        organization.validate.length.should be == 0
+    end
+
+    it "will not fail on source validation, pattern 2" do
+        # given
+        organization.name =  "Lundalogik"
+
+        # when
+        organization.with_source do |source|
+            source.par_se('113:234')
+        end
+
+        # then
+        organization.validate.length.should be == 0
     end
 
     it "will fail on validation if no name is specified" do

--- a/spec/organizations_spec.rb
+++ b/spec/organizations_spec.rb
@@ -287,10 +287,11 @@ describe MoveToGo::Organizations do
         organization.with_source do |source|
             source.par_se('1111')
         end
-        model.add_organization(organization)
 
         # when, then
-        model.organizations.find_duplicates_by("source.id").length.should be > 0
+        assert_raise(MoveToGo::AlreadyAddedError) {
+            model.add_organization(organization)
+        }
     end
 
     it "should allow different source ids" do
@@ -311,10 +312,33 @@ describe MoveToGo::Organizations do
         organization.with_source do |source|
             source.par_se('1112')
         end
-        model.add_organization(organization)
 
         # when, then
-        model.organizations.find_duplicates_by("source.id").length.should be == 0
+        assert_nothing_raised(MoveToGo::AlreadyAddedError) {
+            model.add_organization(organization)
+        }
+    end
+
+    it "Not all organization have source id" do
+        # given
+        model =  MoveToGo::RootModel.new
+
+        organization = MoveToGo::Organization.new
+        organization.name = "name1"
+        organization.integration_id = "1337"
+        model.add_organization(organization)
+
+        organization = MoveToGo::Organization.new
+        organization.name = "name2"
+        organization.integration_id = "1338"
+        organization.with_source do |source|
+            source.par_se('1112')
+        end
+
+        # when, then
+        assert_nothing_raised(MoveToGo::AlreadyAddedError) {
+            model.add_organization(organization)
+        }
     end
 
 end


### PR DESCRIPTION
A simple validation on source id

A source id must now include:
- One ":"
- Only digits allowed
