### PR TITLE
Bump version to 5.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.4.3 (2026-04-02)
+
+Features:
+
+ - Add `wondate` property to Deal class to track when a deal was won/closed successfully [#91](https://github.com/Lundalogik/move-to-go/pull/91)
+
 ## 5.4.0 (2020-02-07)
 
 Features:

--- a/move-to-go.gemspec
+++ b/move-to-go.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
     s.name        = 'move-to-go'
-    s.version     = '5.4.2'
+    s.version     = '5.4.3'
     s.platform    = Gem::Platform::RUBY
     s.authors     = ['Petter Sandholdt', 'Oskar Gewalli', 'Peter Wilhelmsson', 'Anders Pålsson', 'Ahmad Game', 'Rickard Helldin', 'Mikael Davidsson']
     s.email       = 'support@lime.tech'


### PR DESCRIPTION
## Summary
- Bump gem version from 5.4.2 to 5.4.3
- Add changelog entry for the `wondate` property added in #91

## Why
The CI/CD pipeline failed to push the gem after merging #91 because the version wasn't bumped:

```
Repushing of gem versions is not allowed.
Please bump the version number and push a new different release.
```

This PR fixes that by incrementing the version number.